### PR TITLE
Changes class 'filter' from main to nav

### DIFF
--- a/step1-02/demo/README.md
+++ b/step1-02/demo/README.md
@@ -30,9 +30,9 @@ As we saw in the previous demo, HTML elements can be used to describe different 
   <header>
     <h1></h1>
     <div class="addTodo"></div>
-    <nav></nav>
+    <nav class="filter"></nav>
   </header>
-  <main class="filter"></main>
+  <main></main>
   <footer></footer>
 </body>
 ```


### PR DESCRIPTION
The example below states that the `<nav>` element has the class 'filter', but in the example before the class is on `<main>`