### PR TITLE
Add <any, any> props/state to React components

### DIFF
--- a/step1-04/demo/src/App.tsx
+++ b/step1-04/demo/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class App extends React.Component {
+export class App extends React.Component<any, any> {
   render() {
     let text = 'My App';
     return (

--- a/step1-04/demo/src/components/Counter.tsx
+++ b/step1-04/demo/src/components/Counter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class Counter extends React.Component {
+export class Counter extends React.Component<any, any> {
   render() {
     return <p>hello</p>;
   }

--- a/step1-04/final/src/App.tsx
+++ b/step1-04/final/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Counter } from './components/Counter';
 
-export class App extends React.Component {
+export class App extends React.Component<any, any> {
   render() {
     return (
       <div className="App">

--- a/step1-05/demo/src/App.tsx
+++ b/step1-05/demo/src/App.tsx
@@ -3,7 +3,7 @@ import { TodoFooter } from './components/TodoFooter';
 import { TodoHeader } from './components/TodoHeader';
 import { TodoList } from './components/TodoList';
 
-export class TodoApp extends React.Component {
+export class TodoApp extends React.Component<any, any> {
   render() {
     return (
       <div>

--- a/step1-05/demo/src/components/TodoHeader.tsx
+++ b/step1-05/demo/src/components/TodoHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class TodoHeader extends React.Component {
+export class TodoHeader extends React.Component<any, any> {
   render() {
     return (
       <header>

--- a/step1-05/demo/src/components/TodoListItem.tsx
+++ b/step1-05/demo/src/components/TodoListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class TodoListItem extends React.Component {
+export class TodoListItem extends React.Component<any, any> {
   render() {
     return <div />;
   }

--- a/step1-05/exercise/src/App.tsx
+++ b/step1-05/exercise/src/App.tsx
@@ -3,7 +3,7 @@ import { TodoFooter } from './components/TodoFooter';
 import { TodoHeader } from './components/TodoHeader';
 import { TodoList } from './components/TodoList';
 
-export class TodoApp extends React.Component {
+export class TodoApp extends React.Component<any, any> {
   render() {
     return (
       <div>

--- a/step1-05/exercise/src/components/TodoHeader.tsx
+++ b/step1-05/exercise/src/components/TodoHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class TodoHeader extends React.Component {
+export class TodoHeader extends React.Component<any, any> {
   render() {
     return (
       <header>

--- a/step1-05/exercise/src/components/TodoListItem.tsx
+++ b/step1-05/exercise/src/components/TodoListItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export class TodoListItem extends React.Component {
+export class TodoListItem extends React.Component<any, any> {
   render() {
     return (
       <li className="todo">

--- a/step1-05/final/src/TodoApp.tsx
+++ b/step1-05/final/src/TodoApp.tsx
@@ -3,7 +3,7 @@ import { TodoFooter } from './components/TodoFooter';
 import { TodoHeader } from './components/TodoHeader';
 import { TodoList } from './components/TodoList';
 
-export class TodoApp extends React.Component {
+export class TodoApp extends React.Component<any, any> {
   render() {
     return (
       <div>

--- a/step1-05/final/src/components/TodoHeader.tsx
+++ b/step1-05/final/src/components/TodoHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export class TodoHeader extends React.Component {
+export class TodoHeader extends React.Component<any, any> {
   render() {
     return (
       <header>

--- a/step1-05/final/src/components/TodoListItem.tsx
+++ b/step1-05/final/src/components/TodoListItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export class TodoListItem extends React.Component {
+export class TodoListItem extends React.Component<any, any> {
   render() {
     return (
       <li className="todo">

--- a/step1-06/demo/src/TodoApp.tsx
+++ b/step1-06/demo/src/TodoApp.tsx
@@ -3,7 +3,7 @@ import { TodoFooter } from './components/TodoFooter';
 import { TodoHeader } from './components/TodoHeader';
 import { TodoList } from './components/TodoList';
 
-export class TodoApp extends React.Component {
+export class TodoApp extends React.Component<any, any> {
   render() {
     return (
       <div>

--- a/step1-06/demo/src/components/TodoListItem.tsx
+++ b/step1-06/demo/src/components/TodoListItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export class TodoListItem extends React.Component {
+export class TodoListItem extends React.Component<any, any> {
   render() {
     return (
       <li className="todo">


### PR DESCRIPTION
Add default props and state types of `<any, any>` to React components to prevent compiler errors getting in the way of demos.