### PR TITLE
Update Step 1-03 exercise to match instructions

### DIFF
--- a/step1-03/demo/README.md
+++ b/step1-03/demo/README.md
@@ -74,13 +74,12 @@ function addTodo() {
 
 ### Cleanup
 
-Now that our todo has been inserted into the DOM, we can clear the text input and call `updateRemaining()`.
+Now that our todo has been inserted into the DOM, we can clear the text input. In the exercise, we'll also update the count of the remaining todos in the footer from here.
 
 ```js
 function addTodo() {
   ...
   clearInput('.textfield');
-  updateRemaining();
 }
 ```
 

--- a/step1-03/exercise/README.md
+++ b/step1-03/exercise/README.md
@@ -7,7 +7,7 @@ If you don't already have the app running, start it with `npm run static` from t
 1. Add an `onclick` attribute to all three buttons in the navigation.
 2. In each `onclick` call the `filter` function. In our function we need a reference to the clicked button, so pass in the keyword `this` as the only parameter.
 
-### Write an `updateRemaining` function
+### Complete the `updateRemaining` function
 
 1. Get a reference to the span with the `remaining` class, and store it in a variable.
 2. Use [`querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll) to get all of the todos.

--- a/step1-03/exercise/index.html
+++ b/step1-03/exercise/index.html
@@ -47,9 +47,6 @@
     }
 
     function updateRemaining() {
-      const remaining = document.querySelector('.remaining');
-      const todos = document.querySelectorAll('.todo').length;
-      remaining.innerText = todos;
     }
 
     function addTodo() {
@@ -59,7 +56,6 @@
       todo.parentElement.insertBefore(newTodo, todo);
 
       clearInput('.textfield');
-      updateRemaining();
     }
 
     // clearCompleted


### PR DESCRIPTION
While working through exercise **1-03**, I noticed that the `updateRemaining()` function was already implemented. This change makes the starter code consistent with the instructions so that students will write the function body as described.

One option I considered here was deleting the function entirely (including the declaration, instead of just the body). Students do have to write the entire function declaration for the `addTodo()` function in the next step though, and I figured easing them into writing full functions would build momentum. (I teach this stuff to high school students too, and that gradual buildup sometimes matters for novices.) Happy to change this if you all don't agree, though. 😄 

Thanks for open-sourcing this!