### PR TITLE
Add types to redux map functions

### DIFF
--- a/step2-07/demo/src/components/TodoFooter.tsx
+++ b/step2-07/demo/src/components/TodoFooter.tsx
@@ -23,11 +23,11 @@ const TodoFooter = (props: TodoFooterProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ todos }: Store): Partial<TodoFooterProps> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   return {
     clear: () => dispatch(actions.clear())
   };

--- a/step2-07/demo/src/components/TodoHeader.tsx
+++ b/step2-07/demo/src/components/TodoHeader.tsx
@@ -45,11 +45,11 @@ class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState> {
   };
 }
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps(state: Store): Partial<TodoHeaderProps> {
+  return {};
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   return {
     addTodo: (label: string) => dispatch(actions.addTodo(label))
   };

--- a/step2-07/demo/src/components/TodoList.tsx
+++ b/step2-07/demo/src/components/TodoList.tsx
@@ -21,17 +21,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
-}
-
-function mapDispatchToProps(dispatch: any) {
-  return {};
+function mapStateToProps({ todos }: Store): Partial<TodoListProps> {
+  return { todos };
 }
 
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-07/demo/src/components/TodoListItem.tsx
+++ b/step2-07/demo/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actions.remove(id)),
     complete: (id: string) => dispatch(actions.complete(id))

--- a/step2-07/exercise/src/components/TodoFooter.tsx
+++ b/step2-07/exercise/src/components/TodoFooter.tsx
@@ -27,11 +27,11 @@ export const TodoFooter = (props: TodoFooterProps) => {
 /*
 TODO: uncomment this and fill out the below code
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoFooterProps> {
   // TODO: FILL THIS OUT
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   // TODO: FILL THIS OUT
 }
 

--- a/step2-07/exercise/src/components/TodoHeader.tsx
+++ b/step2-07/exercise/src/components/TodoHeader.tsx
@@ -50,11 +50,11 @@ export class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState
 
 TODO: uncomment the following and fill out the TODO's
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoHeaderProps> {
   // TODO: fill this out
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   // TODO: fill this out
 }
 

--- a/step2-07/exercise/src/components/TodoList.tsx
+++ b/step2-07/exercise/src/components/TodoList.tsx
@@ -21,17 +21,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
-}
-
-function mapDispatchToProps(dispatch: any) {
-  return {};
+function mapStateToProps({ todos }: Store): Partial<TodoListProps> {
+  return { todos };
 }
 
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-07/exercise/src/components/TodoListItem.tsx
+++ b/step2-07/exercise/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actions.remove(id)),
     complete: (id: string) => dispatch(actions.complete(id))

--- a/step2-08/demo/src/components/TodoFooter.tsx
+++ b/step2-08/demo/src/components/TodoFooter.tsx
@@ -23,11 +23,11 @@ const TodoFooter = (props: TodoFooterProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ todos }: Store): Partial<TodoFooterProps> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   return {
     clear: () => dispatch(actions.clear())
   };

--- a/step2-08/demo/src/components/TodoHeader.tsx
+++ b/step2-08/demo/src/components/TodoHeader.tsx
@@ -57,11 +57,11 @@ class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState> {
   };
 }
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ filter }: Store): Partial<TodoHeaderProps> {
+  return { filter };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   return {
     addTodo: (label: string) => dispatch(actions.addTodo(label)),
     setFilter: (filter: FilterTypes) => dispatch(actions.setFilter(filter))

--- a/step2-08/demo/src/components/TodoList.tsx
+++ b/step2-08/demo/src/components/TodoList.tsx
@@ -24,17 +24,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoListProps> {
   return { ...state };
 }
 
-function mapDispatchToProps(dispatch: any) {
-  return {};
-}
-
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-08/demo/src/components/TodoListItem.tsx
+++ b/step2-08/demo/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actions.remove(id)),
     complete: (id: string) => dispatch(actions.complete(id))

--- a/step2-08/exercise/src/components/TodoFooter.tsx
+++ b/step2-08/exercise/src/components/TodoFooter.tsx
@@ -22,11 +22,11 @@ const TodoFooter = (props: TodoFooterProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ todos }: Store): Partial<TodoFooterProps> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   return {
     clear: () => dispatch(actions.clear())
   };

--- a/step2-08/exercise/src/components/TodoHeader.tsx
+++ b/step2-08/exercise/src/components/TodoHeader.tsx
@@ -57,11 +57,11 @@ class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState> {
   };
 }
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ filter }: Store): Partial<TodoHeaderProps> {
+  return { filter };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   return {
     addTodo: (label: string) => dispatch(actions.addTodo(label)),
     setFilter: (filter: FilterTypes) => dispatch(actions.setFilter(filter))

--- a/step2-08/exercise/src/components/TodoList.tsx
+++ b/step2-08/exercise/src/components/TodoList.tsx
@@ -24,17 +24,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoListProps> {
   return { ...state };
 }
 
-function mapDispatchToProps(dispatch: any) {
-  return {};
-}
-
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-08/exercise/src/components/TodoListItem.tsx
+++ b/step2-08/exercise/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actions.remove(id)),
     complete: (id: string) => dispatch(actions.complete(id))

--- a/step2-09/demo/src/components/TodoFooter.tsx
+++ b/step2-09/demo/src/components/TodoFooter.tsx
@@ -22,11 +22,11 @@ const TodoFooter = (props: TodoFooterProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ todos }: Store): Partial<TodoFooterProps> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   return {
     clear: () => dispatch(actionsWithService.clear())
   };

--- a/step2-09/demo/src/components/TodoHeader.tsx
+++ b/step2-09/demo/src/components/TodoHeader.tsx
@@ -57,11 +57,11 @@ class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState> {
   };
 }
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ filter }: Store): Partial<TodoHeaderProps> {
+  return { filter };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   return {
     addTodo: (label: string) => dispatch(actionsWithService.addTodo(label)),
     setFilter: (filter: FilterTypes) => dispatch(actions.setFilter(filter))

--- a/step2-09/demo/src/components/TodoList.tsx
+++ b/step2-09/demo/src/components/TodoList.tsx
@@ -24,17 +24,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoListProps> {
   return { ...state };
 }
 
-function mapDispatchToProps(dispatch: any) {
-  return {};
-}
-
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-09/demo/src/components/TodoListItem.tsx
+++ b/step2-09/demo/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actionsWithService.remove(id)),
     complete: (id: string) => dispatch(actionsWithService.complete(id))

--- a/step2-09/exercise/src/components/TodoFooter.tsx
+++ b/step2-09/exercise/src/components/TodoFooter.tsx
@@ -22,11 +22,11 @@ const TodoFooter = (props: TodoFooterProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ todos }: Store): Partial<TodoFooterProps> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoFooterProps> {
   return {
     clear: () => dispatch(actionsWithService.clear())
   };

--- a/step2-09/exercise/src/components/TodoHeader.tsx
+++ b/step2-09/exercise/src/components/TodoHeader.tsx
@@ -57,11 +57,11 @@ class TodoHeader extends React.Component<TodoHeaderProps, TodoHeaderState> {
   };
 }
 
-function mapStateToProps(state: Store) {
-  return { ...state };
+function mapStateToProps({ filter }: Store): Partial<TodoHeaderProps> {
+  return { filter };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Partial<TodoHeaderProps> {
   return {
     addTodo: (label: string) => dispatch(actionsWithService.addTodo(label)),
     setFilter: (filter: FilterTypes) => dispatch(actions.setFilter(filter))

--- a/step2-09/exercise/src/components/TodoList.tsx
+++ b/step2-09/exercise/src/components/TodoList.tsx
@@ -24,17 +24,12 @@ const TodoList = (props: TodoListProps) => {
   );
 };
 
-function mapStateToProps(state: Store) {
+function mapStateToProps(state: Store): Partial<TodoListProps> {
   return { ...state };
 }
 
-function mapDispatchToProps(dispatch: any) {
-  return {};
-}
-
 const component = connect(
-  mapStateToProps,
-  mapDispatchToProps
+  mapStateToProps
 )(TodoList);
 
 export { component as TodoList };

--- a/step2-09/exercise/src/components/TodoListItem.tsx
+++ b/step2-09/exercise/src/components/TodoListItem.tsx
@@ -27,13 +27,11 @@ class TodoListItem extends React.Component<TodoListItemProps, {}> {
   }
 }
 
-function mapStateToProps({ todos }: Store) {
-  return {
-    todos
-  };
+function mapStateToProps({ todos }: Store): Pick<TodoListItemProps, 'todos'> {
+  return { todos };
 }
 
-function mapDispatchToProps(dispatch: any) {
+function mapDispatchToProps(dispatch: any): Pick<TodoListItemProps, 'remove' | 'complete'> {
   return {
     remove: (id: string) => dispatch(actionsWithService.remove(id)),
     complete: (id: string) => dispatch(actionsWithService.complete(id))


### PR DESCRIPTION
For the `mapStateToProps` and `mapDispatchToProps` functions in day 2 parts 7-9, I think they might be a little easier to understand if the return types are specified. I also made some other minor updates to those functions.