### PR TITLE
Fixing typos in README.md

### DIFF
--- a/step1-01/exercise/README.md
+++ b/step1-01/exercise/README.md
@@ -1,6 +1,6 @@
 # Step 1 Exercise
 
-The power of HTML is its ability to represent complex information in a way that conveys meaning. In this exercise you are going to be creating an HTML page for my favorite recipe.
+The power of HTML is its ability to represent complex information in a way that conveys meaning. In this exercise you are going to be creating a HTML page for my favorite recipe.
 
 ## The Exercise
 
@@ -14,7 +14,7 @@ The power of HTML is its ability to represent complex information in a way that 
 
 It's great how a single meal can take you back dozens of years. This is one of those recipes that never seems to fail to impress.
 
-I learned this recipe for the cousin of one of my college friends back in Nashville Tenessee. We had an amazing 4th of July feast which included this recipe and some bratworst like these Wisconsin Beer Brats https://www.culinaryhill.com/wisconsin-beer-brats/
+I learned this recipe from the cousin of one of my college friends back in Nashville Tenessee. We had an amazing 4th of July feast which included this recipe and some bratwurst like these Wisconsin Beer Brats https://www.culinaryhill.com/wisconsin-beer-brats/
 
 Prep Time: 10 minutes
 Cook time: 3+ hours
@@ -22,7 +22,7 @@ Servings: 12
 
 **Ingredients**
 1LB Bacon chopped
-3 Cans Bush's Origin Baked Beans
+3 Cans Bush's Original Baked Beans
 1 Walla Wall Onion chopped
 2 ground garlic cloves
 3 Tablespoons of mustard
@@ -33,15 +33,15 @@ Servings: 12
 Cook bacon until it is mostly cooked, then drain most of the grease and put aside
 Cook onion in remaining bacon grease
 Combine onions and bacon, then add garlic, cook for a few more minutes
-Add beans and get up to simmer temperate
+Add beans and get up to simmer temperature
 Add mustard until your beans are nice and yellow
 Add molassas until color darkens again
 Add brown sugar until properly sweet
-Simmer for a long time, occassionally sturing
+Simmer for a long time, occassionally stirring
 
-**Expert Tipes**
+**Expert Tips**
 Burning off most of the liquid gives you nice, hearty, sticky beans.
-If the beans get too try, you can always add beer!
+If the beans get too dry, you can always add beer!
 
 **Nutritional Information**
 Calories: lots

--- a/step1-01/exercise/README.md
+++ b/step1-01/exercise/README.md
@@ -7,7 +7,7 @@ The power of HTML is its ability to represent complex information in a way that 
 1. Create a recipe page to host our recipe (page title, headings, sections, paragraphs, lists etc)
 2. Use title, header, main, footer, headings (h1/h2 etc), paragraphs, lists
 3. Use ordered and unordered lists appropriately
-4. Add the `baked_beans.jpg` iagine included in this folder
+4. Add the `baked_beans.jpg` image included in this folder
 5. Add an anchor tag around 'Wisconsin Beer Brats'
 
 ## 4th of July Baked Beans


### PR DESCRIPTION
Fixing typos:
- `iagine` -> `image`
- `an` -> `a`
- `for` -> `from`
- `bratworst` -> `bratwurst`
- `Origin` -> `Original`
- `temperate` -> `temperature`
- `sturing` -> `stirring`
- `Tipes` -> `Tips`
- `try` -> `dry`