### PR TITLE
Fix flux image path

### DIFF
--- a/step2-05/demo/README.md
+++ b/step2-05/demo/README.md
@@ -18,7 +18,7 @@ As a reminder, the problem that we want to address are:
 
 Redux is an implementation of the Flux architectural pattern:
 
-![Flux Diagram](../assets/flux.png)
+![Flux Diagram](../../assets/flux.png)
 
 ### View
 


### PR DESCRIPTION
The Flux diagram is located one upper folder, so added an extra jump.

Correct url: https://github.com/Microsoft/frontend-bootcamp/blob/master/assets/flux.png