### PR TITLE
Fix convert undefined to object in step 1-6

### DIFF
--- a/step1-06/demo/src/components/TodoList.tsx
+++ b/step1-06/demo/src/components/TodoList.tsx
@@ -3,7 +3,7 @@ import { TodoListItem } from './TodoListItem';
 
 export class TodoList extends React.Component<any, any> {
   render() {
-    const { filter, todos } = this.props;
+    const { filter, todos = {} } = this.props;
 
     // filteredTodos returns an array of filtered todo keys [01,02,03]
     const filteredTodos = Object.keys(todos).filter(id => {


### PR DESCRIPTION
Trying to execute `Object.keys` in `undefined` throws an error. Defaulting the value to an empty object returns an empty array.