### PR TITLE
Set script language to typescript (JSX requires)

### DIFF
--- a/step1-04/demo/index.html
+++ b/step1-04/demo/index.html
@@ -21,7 +21,7 @@
   background: green;
 }
     </pre>
-    <pre data-lang="javascript">
+    <pre data-lang="typescript">
 ReactDOM.render(
   &lt;div>Hello World&lt;/div>, 
   document.getElementById('app')


### PR DESCRIPTION
This addresses issue #213. JSX does not render in straight JS in browsers tested as today.  Codepen supports TypeScript or Babel for JSX. I decided on TypeScript over Babel (which also would work), because later lessons are on TypeScript
