### PR TITLE
Exclude outDir from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true
   },
-  "exclude": ["node_modules", "docs"]
+  "exclude": ["node_modules", "docs", "dist"]
 }


### PR DESCRIPTION
Consuming output as input is generally discouraged since it adds memory overhead without adding value.  As a bonus, this makes it possible to build twice in a row without cleaning in between (though I suspect this file is only for editor support and the actual build happens through webpack).